### PR TITLE
add toValidationRule method

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,23 @@ Lastly, you can create an empty options list like this:
 Options::empty();
 ```
 
+### Using for validation
+
+For convenience, you can quickly turn the same options you passed to the front end, as a back end validation rule.
+This will account for nullable options too.
+
+```php
+$options = Options::forArray([
+    'gondor' => 'Gondor',
+    'rohan' => 'Rohan',
+    'mordor' => 'Mordor',
+]);
+
+$request->validate([
+    'my_options_input' => $options->toValidationRule()
+]);
+```
+
 ## Testing
 
 ```bash

--- a/src/Options.php
+++ b/src/Options.php
@@ -11,7 +11,9 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\Rule;
 use JsonSerializable;
 use MyCLabs\Enum\Enum as MyclabsEnum;
 use Spatie\Enum\Enum as SpatieEnum;
@@ -203,6 +205,21 @@ class Options implements Arrayable, Jsonable, JsonSerializable, Stringable
                 ))
             )
             ->toArray();
+    }
+
+    /**
+     * @return array<int, string|In>
+     */
+    public function toValidationRule(): array
+    {
+        $rulesArray = [];
+        if ($this->nullable) {
+            $rulesArray[] = 'nullable';
+        }
+
+        $rulesArray[] = Rule::in(array_filter(Arr::pluck($this->toArray(), 'value')));
+
+        return $rulesArray;
     }
 
     public function toJson($options = 0)

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -190,3 +190,44 @@ it('will use a selectable interface select option if it exists and can append mo
         ],
     ]);
 });
+
+it('can be turned into a laravel validation rule', function () {
+    $rules = Options::create(new NativeEnumProvider(StringEnum::class))
+                    ->toValidationRule();
+
+    expect($rules)
+        ->toBeArray()
+        ->toHaveCount(1);
+
+    $options = $rules[0];
+    $optionsString = $options->__toString();
+
+    expect($options)->toBeInstanceOf(\Illuminate\Validation\Rules\In::class);
+    expect($optionsString)
+        ->toBeString()
+        ->toBe('in:"frodo","sam","merry","pippin"');
+});
+
+it('can be turned into a laravel validation rule when nullable', function () {
+    $rules = Options::create(new NativeEnumProvider(StringEnum::class))
+                    ->nullable()
+                    ->toValidationRule();
+
+    expect($rules)
+        ->toBeArray()
+        ->toHaveCount(2);
+
+    $nullable = $rules[0];
+
+    expect($nullable)
+        ->toBeString()
+        ->toBe('nullable');
+
+    $options = $rules[1];
+    $optionsString = $options->__toString();
+
+    expect($options)->toBeInstanceOf(\Illuminate\Validation\Rules\In::class);
+    expect($optionsString)
+        ->toBeString()
+        ->toBe('in:"frodo","sam","merry","pippin"');
+});


### PR DESCRIPTION
Adds a `toValidationRule` method which returns the options are an instance of `Illuminate\Validation\Rules\In`. Useful for quickly use the same options that were passed to the front end as a validation rule in the back-end.